### PR TITLE
Exclude div from soup

### DIFF
--- a/debugger.py
+++ b/debugger.py
@@ -1,0 +1,20 @@
+from bs4 import BeautifulSoup
+from requests import get
+from tag_mapper import TagMapper
+
+post_url = "https://medium.freecodecamp.org/learning-ruby-from-zero-to-hero-90ad4eecc82d"
+post_content = get(post_url, stream=True).content
+soup = BeautifulSoup(post_content, 'html.parser')
+medium_post = soup.find_all("div", {"class": "sectionLayout--insetColumn"})
+medium_post[0]
+
+markdown_file = open("post.md", "w+")
+
+for section in medium_post:
+    new_section = [tag for tag in section if tag.name != 'div']
+    for tag in section:
+        markdown_tag = TagMapper(tag).to_markdown()
+        markdown_file.write(markdown_tag)
+        markdown_file.write("\n\n")
+
+markdown_file.close()

--- a/m2m/medium_to_markdown.py
+++ b/m2m/medium_to_markdown.py
@@ -11,12 +11,15 @@ class MediumToMarkdown:
         markdown_file = open("post.md", "w+")
 
         for section in self.medium_post():
-            for tag in section:
+            for tag in self.exclude_div_tags_from(section):
                 markdown_tag = TagMapper(tag).to_markdown()
                 markdown_file.write(markdown_tag)
                 markdown_file.write("\n\n")
 
         markdown_file.close()
+
+    def exclude_div_tags_from(self, section):
+        return [tag for tag in section if tag.name != 'div']
 
     def medium_post(self):
         post_content = self.medium_post_response().content


### PR DESCRIPTION
Medium put the `author` between the title and the whole post content.

<img width="763" alt="screen shot 2018-12-01 at 16 24 49" src="https://user-images.githubusercontent.com/5835798/49331576-70b2f800-f586-11e8-81e9-1d910a3e8774.png">

The idea of this fix is to remove the `div` tag (author element) from the soup.
Solution: I used list comprehension to exclude the div