### PR TITLE
add div-parse

### DIFF
--- a/m2m/core.py
+++ b/m2m/core.py
@@ -1,3 +1,4 @@
+# coding: utf8
 import os
 import sys
 

--- a/m2m/gist_to_codeblock.py
+++ b/m2m/gist_to_codeblock.py
@@ -1,3 +1,4 @@
+# coding: utf8
 import os
 
 from bs4 import BeautifulSoup

--- a/m2m/medium_to_markdown.py
+++ b/m2m/medium_to_markdown.py
@@ -12,9 +12,13 @@ class MediumToMarkdown:
         markdown_file = open("post.md", "w+", encoding="utf8")
 
         for section in self.medium_post():
-            for tag in self.exclude_div_tags_from(section):
+            # for tag in self.exclude_div_tags_from(section):
+            for tag in section:
+                if tag.name == 'div' and 'uiScale-caption--regular' in tag["class"]:
+                    continue
                 markdown_tag = TagMapper(tag).to_markdown()
-                markdown_file.write(markdown_tag)
+                if markdown_tag:
+                    markdown_file.write(markdown_tag)
                 markdown_file.write("\n\n")
 
         markdown_file.close()

--- a/m2m/medium_to_markdown.py
+++ b/m2m/medium_to_markdown.py
@@ -1,3 +1,4 @@
+# coding: utf8
 from bs4 import BeautifulSoup
 from requests import get
 from tag_mapper import TagMapper
@@ -8,7 +9,7 @@ class MediumToMarkdown:
         self.post_url = post_url
 
     def transform(self):
-        markdown_file = open("post.md", "w+")
+        markdown_file = open("post.md", "w+", encoding="utf8")
 
         for section in self.medium_post():
             for tag in self.exclude_div_tags_from(section):

--- a/m2m/medium_to_markdown.py
+++ b/m2m/medium_to_markdown.py
@@ -9,11 +9,13 @@ class MediumToMarkdown:
         self.post_url = post_url
 
     def transform(self):
-        markdown_file = open("post.md", "w+", encoding="utf8")
+        responses = self.medium_post()
+        fname = '-'.join(responses.url.split('/')[-1].split('-')[:-1])
 
-        for section in self.medium_post():
-            # for tag in self.exclude_div_tags_from(section):
+        markdown_file = open(f"{fname}.md", "w+", encoding="utf8")
+        for section in responses:
             for tag in section:
+                # skip author infomation
                 if tag.name == 'div' and 'uiScale-caption--regular' in tag["class"]:
                     continue
                 markdown_tag = TagMapper(tag).to_markdown()
@@ -22,9 +24,6 @@ class MediumToMarkdown:
                 markdown_file.write("\n\n")
 
         markdown_file.close()
-
-    def exclude_div_tags_from(self, section):
-        return [tag for tag in section if tag.name != 'div']
 
     def medium_post(self):
         post_content = self.medium_post_response().content

--- a/m2m/tag_mapper.py
+++ b/m2m/tag_mapper.py
@@ -1,3 +1,4 @@
+# coding: utf8
 from functools import reduce
 from gist_to_codeblock import GistToCodeblock
 from urllib.parse import unquote

--- a/m2m/tag_mapper.py
+++ b/m2m/tag_mapper.py
@@ -68,11 +68,11 @@ class TagMapper:
         return f"#### {self.tag.text}"
 
     def parse_text(self, result_text, current_text):
-        print(current_text.name, )
+        # print(current_text.name, )
         if current_text.name == "code":
             return f"{result_text}`{current_text.text}`"
         elif current_text.name == "a":
-            print(current_text['href'])
+            # print(current_text['href'])
             anchor_url = unquote(current_text['href']
                                  .replace("https://medium.com/r/?url=", ""))
             return f"{result_text}[{current_text.text}]({anchor_url})"

--- a/m2m/tag_mapper.py
+++ b/m2m/tag_mapper.py
@@ -4,22 +4,12 @@ from gist_to_codeblock import GistToCodeblock
 from urllib.parse import unquote
 
 
-class Counter(object):
-    def __init__(self, fun):
-        self._fun = fun
-        self.counter = ''
-
-    def __call__(self, *args, **kwargs):
-        self.counter += 1
-        return self._fun(*args, **kwargs)
-
-
 class TagMapper:
     def __init__(self, tag):
         self.tag = tag
 
     def to_markdown(self):
-        print(self.tag.name)
+        # print(self.tag.name)
         if self.tag.name == 'h1':
             return self.markdown_h1()
         elif self.tag.name == 'h3':

--- a/m2m/tag_mapper.py
+++ b/m2m/tag_mapper.py
@@ -31,12 +31,12 @@ class TagMapper:
     def parse_div(self, div_tag):
         for child in div_tag:
             if child.name == 'div':
-                self.s += self.parse_div(child) if self.parse_div(child) else ''
+                div_string = self.parse_div(child)
+                self.s += div_string if div_string else ''
             elif child.name == 'a' and child.has_attr('href'):
                 link_text = reduce(lambda result_text, current_text: self.parse_text(
                     result_text, current_text), child, "")
                 self.s += f"[{link_text}]({child['href']})"
-            self.s += temp
 
     def markdown_div(self):
         self.s = ''


### PR DESCRIPTION
This is a great project and it is very helpful to me.
When I used it, I found some minor problems.
1. There may be coding problems running under windows10, so I specified the encoding format of all python files as `utf8`. Also, the output markdown file encoding format is also specified as `utf8`
2. In the `medium_to_markdown.py` file, I found out that you skip parsing the `div` content. For some of my articles that need to be converted, these will be missing some content, so I added the parsing of the `div`. However, the conversion of author information (avatar, name, post information, reading time) is skipped. Although this part of the conversion may be a bit ugly :).
3. Also, when converting the article, I encountered two `label` not parse, causing a running error, `<br>` and `<img>`
I fixed the above problem, maybe some places are not good enough. I hope you can make suggestions and improve it. This is the link to the article I tested https://medium.com/@yaroslavvb/icml-2018-notes-aa7307a0b17