### PR TITLE
Update urllib3 version for vulnerability reason

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ source m2menv/bin/activate
 ```
 
 Run this command to install all required libraries
+
 ```bash
-pip install -r dev-requirements.txt
+pip install -r requirements.txt
 ```
 
 - [Python 3](https://docs.python.org/3/)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ chardet==3.0.4
 idna==2.7
 python-dotenv==0.9.1
 requests==2.20.1
-urllib3==1.24.1
+urllib3==1.24.3


### PR DESCRIPTION
## What's this PR?

The `urllib3` version 1.24.1 has a security vulnerability. The idea of this PR is to upgrade the version to >= 1.24.2. So I updated it to 1.24.3 (the latest version for today)

## Github Security Alert

<img width="745" alt="Screen Shot 2019-05-19 at 11 05 43" src="https://user-images.githubusercontent.com/5835798/57983267-46ff6780-7a26-11e9-9659-279e97fe1bfe.png">
